### PR TITLE
Minor edit to getting_started.md

### DIFF
--- a/docs/micros/getting_started.md
+++ b/docs/micros/getting_started.md
@@ -239,7 +239,7 @@ Installing collected packages: Werkzeug, itsdangerous, MarkupSafe, Jinja2, click
 </Tabs>
 
 #### Visiting our Endpoint
-Let's visit the endpoint the endpoint we saved earlier.  
+Let's visit the endpoint ( from the endpoint URL we saved earlier).  
 
 (If you didn't save it, simply type `deta details` into the CLI, which will give you the endpoint alongside other information about your Micro).
 


### PR DESCRIPTION
Correction for minor error spotted.
"Let's visit the endpoint endpoint we saved earlier."  here the **repetition of the word "endpoint"** seemed to be a mistake made while writing the document.