### PR TITLE
Keys explainer

### DIFF
--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -58,3 +58,7 @@ export DETA_ACCESS_TOKEN=<access_token_here>
 ```
 
 You are now free to use the `deta` command within GitPod!
+
+#### Using Deta in GitHub Actions with Access Tokens
+
+A usable example of using Deta within GitHub actions is [here](https://github.com/BogDAAAMN/deta-deploy-action).

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -14,10 +14,10 @@ Custom subdomains are already in alpha, if you need one for your project, please
 
 Deta offers 3 types of secrets / keys / tokens:
 
-1. **Project Keys**: This key interacts with your data and resources inside a project. In this case it's used to read and write from Bases. A project key will be created for you when you create a project and you can manage all of a project's keys from the *'Settings'* option in a project's sidebar. If this key is leaked, the data stored in any of the given project's Bases is compromised. 
+1. **Project Keys**: This key interacts with your data and resources inside a project (currently allowing reads and writes for the project's Bases). A project key will be created for you when you create a project, while you can manage all of a project's keys from the *'Settings'* option in any project's sidebar. If this key is leaked, the data stored in any of the connected project's Bases is compromised. 
 
-2. **API Keys**: This is an optional key to protect your Micro HTTP endpoint or implement client-based rules. Creating API Keys from the Deta CLI is described [here](/docs/cli/commands#deta-auth-create-api-key). Read more about API Keys [here](https://en.wikipedia.org/wiki/Application_programming_interface_key). If this key is leaked, your micro endpoint can be used by unwanted clients.
+2. **API Keys**: This is an optional key to protect your Micro HTTP endpoint or to implement client-based rules. Creating API Keys from the Deta CLI is described [here](/docs/cli/commands#deta-auth-create-api-key). Read more about API Keys [here](https://en.wikipedia.org/wiki/Application_programming_interface_key). If this key is leaked, your micro endpoint can be used by unwanted clients.
 
-3. **Access Tokens**: This token lets other programs manage (create, modify & delete) your Micros, projects and Bases on your behalf. It's mainly used to let you have programatic access to our API. Use cases: CI/CD, Gitpod, GitHub actions. Information on Deta Access Tokens is [here](/docs/cli/auth#deta-access-tokens). If this key is leaked, your whole Deta account is compromised.
+3. **Access Tokens**: This token lets other programs manage (create, modify & delete) your Micros, Projects and Bases on your behalf. It's mainly used to let you have programmatic access to our API. Use cases: CI/CD, Gitpod, GitHub actions. Information on Deta Access Tokens is [here](/docs/cli/auth#deta-access-tokens). If this key is leaked, your whole Deta account is compromised.
 
 These types of keys are not unique to Deta, all other cloud providers use some variant of them.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -18,6 +18,6 @@ Deta offers 3 types of secrets / keys / tokens:
 
 2. **API Keys**: This is an optional key to protect your Micro HTTP endpoint or implement client-based rules. Creating API Keys from the Deta CLI is described [here](/docs/cli/commands#deta-auth-create-api-key). Read more about API Keys [here](https://en.wikipedia.org/wiki/Application_programming_interface_key). If this key is leaked, your micro endpoint can be used by unwanted clients.
 
-3. **Access Tokens**: This lets other programs manage (create, modify & delete) your Micros, projects and Bases on your behalf. It's mainly used to let you have programatic access to our API. Use cases: CI/CD, Gitpod, GitHub actions. Information on Deta Access Tokens is [here](/docs/cli/auth#deta-access-tokens). If this key is leaked, your whole Deta account is compromised.
+3. **Access Tokens**: This token lets other programs manage (create, modify & delete) your Micros, projects and Bases on your behalf. It's mainly used to let you have programatic access to our API. Use cases: CI/CD, Gitpod, GitHub actions. Information on Deta Access Tokens is [here](/docs/cli/auth#deta-access-tokens). If this key is leaked, your whole Deta account is compromised.
 
 These types of keys are not unique to Deta, all other cloud providers use some variant of them.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -9,3 +9,15 @@ sidebar_label: FAQs
 Custom domains and subdomains will be added shortly. 
 
 Custom subdomains are already in alpha, if you need one for your project, please let us know.
+
+### What are all the different 'keys' for?
+
+Deta offers 3 types of secrets / keys / tokens:
+
+1. **Project Keys**: This key interacts with your data and resources inside a project. In this case it's used to read and write from Bases. A project key will be created for you when you create a project and you can manage all of a project's keys from the *'Settings'* option in a project's sidebar. If this key is leaked, the data stored in any of the given project's Bases is compromised. 
+
+2. **API Keys**: This is an optional key to protect your Micro HTTP endpoint or implement client-based rules. Creating API Keys from the Deta CLI is described [here](/docs/cli/commands#deta-auth-create-api-key). Read more about API Keys [here](https://en.wikipedia.org/wiki/Application_programming_interface_key). If this key is leaked, your micro endpoint can be used by unwanted clients.
+
+3. **Access Tokens**: This lets other programs manage (create, modify & delete) your Micros, projects and Bases on your behalf. It's mainly used to let you have programatic access to our API. Use cases: CI/CD, Gitpod, GitHub actions. Information on Deta Access Tokens is [here](/docs/cli/auth#deta-access-tokens). If this key is leaked, your whole Deta account is compromised.
+
+These types of keys are not unique to Deta, all other cloud providers use some variant of them.


### PR DESCRIPTION
Add an explainer to the different types of keys / tokens to the docs.
- Note we use `key` for projects & api, while `token` for access via CI/CD in the product.

For access tokens, added a link to Bogdan's GitHub Action example.

Content:
1. https://deploy-preview-77--loving-volhard-d1b09a.netlify.app/docs/faqs#what-are-all-the-different-keys-for
2. https://deploy-preview-77--loving-volhard-d1b09a.netlify.app/docs/cli/auth#using-deta-in-github-actions-with-access-tokens