### PR TITLE
Typo in python cron snippet

### DIFF
--- a/docs/micros/cron.md
+++ b/docs/micros/cron.md
@@ -228,7 +228,7 @@ def say_hello(event):
 
 # stacking run and cron
 @app.lib.run(action='time') # action 'time'
-@app.lib.cron():
+@app.lib.cron()
 def print_time(event):
     return f"it is {datetime.now()}" 
 ```


### PR DESCRIPTION
on the section `Cron and Run` the `@app.lib.cron()` has a colon `:`
and i believe that will cause an error.

this PR removes it.