### PR TITLE
Add javascript example for accessing pre-set environment variables

### DIFF
--- a/docs/micros/details.md
+++ b/docs/micros/details.md
@@ -3,7 +3,8 @@ id: details
 title: Pre-set Environment Variables
 sidebar_label: Pre-set Environment Variables
 ---
-
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 ### What are they?
 Pre-set environment variables are essentially just pieces of information about your Micro and project, permanently stored in your Micro's environment. 
@@ -21,6 +22,17 @@ In some cases, pre-set environment variables can be useful in your code. This gu
 #### Use cases
 ##### Absolute link
 In some cases, your resource may need to respond with an absolute link to some of the content it is hosting, along with the relative resource link. This can be done with the following code:
+
+
+<Tabs
+    groupId="preferred-language"
+    defaultValue="python"
+    values={[
+        {label: 'JavaScript', value:'js', },
+        {label: 'Python', value: 'python',},
+    ]}
+>
+<TabItem value="python">
 
 ```py
 import os
@@ -40,6 +52,30 @@ async def get_resource_location(resource_id):
       "abs_path": f"https://{hostname}/resource/{resource_id}"
        }
 ```
+
+</TabItem>
+<TabItem value="js">
+
+```js
+const express = require('express');
+const app = express();
+
+hostname = process.env.DETA_PATH
+    ? `${process.env.DETA_PATH}.deta.dev`
+    : 'localhost';
+
+app.get('/resource_location/:resource_id', (req, res) => {
+    return res.send({
+        rel_path: `/resource/${req.params.resource_id}`,
+        abs_path: `https://${hostname}/resource/${req.params.resource_id}`
+    });
+});
+
+module.exports = app;
+```
+
+</TabItem>
+</Tabs>
 
 ### Runtime
 `DETA_RUNTIME` contains a boolean value that indicates if your script is running on a Micro. When accessing this variable in a Micro, expect to get a `True` from it. 


### PR DESCRIPTION
I notice here https://docs.deta.sh/docs/micros/details there is no javascript example. 
This PR add javascript example for accessing pre-set environment variables.

I dont know if this is necessary or not, but here it is. I tested it my-self and it works like this:

![image](https://user-images.githubusercontent.com/20186786/121347099-ffbbda80-c950-11eb-8ffe-4e4255a9351f.png)
