### PR TITLE
Fix code block in Static Files quick start

### DIFF
--- a/docs/tutorials/static_files.md
+++ b/docs/tutorials/static_files.md
@@ -10,7 +10,7 @@ The guide assumes you have a `build` folder with your static app and have the [D
 ### Setup
 Create a directory `static-app` and change the current directory to it.
   ```shell
-  $ mkdir static-app && static-app
+  $ mkdir static-app && cd static-app
   ```
 Copy your `build` folder into the `static-app` directory.
 


### PR DESCRIPTION
I corrected the command the reader runs to create the `static-app` folder and enter it.