### PR TITLE
Fix syntax error for Js code snippet

### DIFF
--- a/docs/micros/env_vars.md
+++ b/docs/micros/env_vars.md
@@ -107,7 +107,7 @@ While using our SDKs(the latest versions) within a Deta Micro, you can omit spec
 <TabItem value="js">
 
 ```js
-const { Base, Drive } = require 'deta';
+const { Base, Drive } = require('deta');
 
 const base = Base('base_name');
 const drive = Drive('drive_name');


### PR DESCRIPTION
`const { Base, Drive } = require 'deta';` produce following error when i run `node index.js`
```sh
E:\Deta\default\app\index.js:12
const { Base, Drive } = require 'deta'
                                ^^^^^^

SyntaxError: Unexpected string
←[90m    at Object.compileFunction (node:vm:352:18)←[39m
←[90m    at wrapSafe (node:internal/modules/cjs/loader:1031:15)←[39m
←[90m    at Module._compile (node:internal/modules/cjs/loader:1065:27)←[39m
←[90m    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)←[39m
←[90m    at Module.load (node:internal/modules/cjs/loader:981:32)←[39m
←[90m    at Function.Module._load (node:internal/modules/cjs/loader:822:12)←[39m
←[90m    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)←[39m
←[90m    at node:internal/main/run_main_module:17:47←[39m
```

Place it in bracket fixed the error