### PR TITLE
Typo

### DIFF
--- a/docs/micros/deploy_on_deta_button.md
+++ b/docs/micros/deploy_on_deta_button.md
@@ -19,7 +19,7 @@ An example button that deploys a sample Python Micro to Deta:
 You can let users deploy your GitHub, Gitlab BitBucket (Git) repo quickly by adding the following markup:
 
 ```md
-[![Deploy](https://button.deta.dev/1/svg)](https://go.deta.dev/deploy?repo=your-repo-url)
+[![Deploy](https://button.deta.dev/1/svg)](https://go.deta.dev/deploy)
 ```
 
 :::note


### PR DESCRIPTION
Updated https://go.deta.dev/deploy?repo=your-repo-url to https://go.deta.dev/deploy. Because I got error while I pasting previous one and  after changing to go.deta.dev/deploy it worked!. (ps: I changed repo query to my repo's url. But it didn't work)