### PR TITLE
Replace slack references with Discord

### DIFF
--- a/docs/base/async_sdk.md
+++ b/docs/base/async_sdk.md
@@ -299,4 +299,4 @@ loop.run_until_complete(fetch_items())
 
 ## Feedback
 
-Please provide us with feedback and bug reports on slack, [github](https://github.com/deta/deta-python) or send us an email at *team@deta.sh*. We appreciate any feedback.
+Please provide us with feedback and bug reports on discord, [github](https://github.com/deta/deta-python) or send us an email at *team@deta.sh*. We appreciate any feedback.

--- a/docs/base/base_ui.md
+++ b/docs/base/base_ui.md
@@ -61,4 +61,4 @@ We hope you enjoy Base UI!
 
 Base UI is still in Beta; it has been internally tested but may have some uncaught bugs or issues. 
 
-We'd love to hear from you: please reach us at `hello@deta.sh` or on Slack if you have any feedback!
+We'd love to hear from you: please reach us at `hello@deta.sh` or on Discord if you have any feedback!

--- a/docs/drive/drive_ui.md
+++ b/docs/drive/drive_ui.md
@@ -57,4 +57,4 @@ We hope you enjoy Drive UI!
 
 Drive UI is still in Beta; it has been internally tested but may have some uncaught bugs or issues. 
 
-We'd love to hear from you: please reach us at `hello@deta.sh` or on Slack if you have any feedback!
+We'd love to hear from you: please reach us at `hello@deta.sh` or on Discord if you have any feedback!

--- a/docs/home.md
+++ b/docs/home.md
@@ -78,5 +78,5 @@ You create and update micros using the CLI.
 We have answered some [FAQs](faqs.md) in these docs, but we are here to help and would love to hear what you think!
 
 If you have any questions or feedback, you can reach us:
-- [Discord](https://discord.gg/cGZV5Shc)
+- [Discord](https://go.deta.dev/discord)
 - [hello@deta.sh](mailto:hello@deta.sh)

--- a/docs/home.md
+++ b/docs/home.md
@@ -78,5 +78,5 @@ You create and update micros using the CLI.
 We have answered some [FAQs](faqs.md) in these docs, but we are here to help and would love to hear what you think!
 
 If you have any questions or feedback, you can reach us:
-- [Slack](https://join.slack.com/t/deta-hq/shared_invite/zt-ej8ygys5-1szO9l~y052Hg04FXdV1iA)
+- [Discord](https://discord.gg/cGZV5Shc)
 - [hello@deta.sh](mailto:hello@deta.sh)

--- a/docs/micros/custom_domains.md
+++ b/docs/micros/custom_domains.md
@@ -68,7 +68,7 @@ Check the following if you are experiencing issues in setting up a custom domain
 3. Check if there is a CAA record set up for your domain. If yes, make sure you have [set up the necessary CAA record](#caa-records).
 
 :::warning
-If you had to change something from the steps mentioned above, [email us](<mailto:aavash@deta.sh?subject=Re-enable custom domain>) or [let us know in discord](https://discord.gg/cGZV5Shc). This is important as our systems eventually stop trying to assign the custom domain on errors. Manual re-enabling of the domain might be required.
+If you had to change something from the steps mentioned above, [email us](<mailto:aavash@deta.sh?subject=Re-enable custom domain>) or [let us know in discord](https://go.deta.dev/discord). This is important as our systems eventually stop trying to assign the custom domain on errors. Manual re-enabling of the domain might be required.
 :::  
 
 ### Unsupported Top Level Domains 

--- a/docs/micros/custom_domains.md
+++ b/docs/micros/custom_domains.md
@@ -68,7 +68,7 @@ Check the following if you are experiencing issues in setting up a custom domain
 3. Check if there is a CAA record set up for your domain. If yes, make sure you have [set up the necessary CAA record](#caa-records).
 
 :::warning
-If you had to change something from the steps mentioned above, [email us](<mailto:aavash@deta.sh?subject=Re-enable custom domain>) or [let us know in slack](https://deta.hq.slack.com). This is important as our systems eventually stop trying to assign the custom domain on errors. Manual re-enabling of the domain might be required.
+If you had to change something from the steps mentioned above, [email us](<mailto:aavash@deta.sh?subject=Re-enable custom domain>) or [let us know in discord](https://discord.gg/cGZV5Shc). This is important as our systems eventually stop trying to assign the custom domain on errors. Manual re-enabling of the domain might be required.
 :::  
 
 ### Unsupported Top Level Domains 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,8 +39,8 @@ module.exports = {
           title: 'Community',
           items: [
             {
-              label: 'Slack',
-              href: 'https://deta-hq.slack.com/',
+              label: 'Discord',
+              href: 'https://discord.gg/cGZV5Shc',
             },
             {
               label: 'Twitter',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
           items: [
             {
               label: 'Discord',
-              href: 'https://discord.gg/cGZV5Shc',
+              href: 'https://go.deta.dev/discord',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
Deta Slack workplace has been deleted.

This PR replaces all slack references to discord.