### PR TITLE
Set logo link to deta.sh

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ module.exports = {
       logo: {
         alt: 'Deta Logo',
         src: 'img/logo.svg',
-        target: '/docs/home',
+        href: 'https://deta.sh',
       },
       items: [
         {


### PR DESCRIPTION
Switch the header logo link to deta.sh. This will make it easier to move back and forth between the document and the home page. The top of the document will still be accessible from docs link in the header.