### PR TITLE
fix: Broken URL for install CLI

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -8,7 +8,7 @@ sidebar_label: Command Reference
 
 **deta** is a CLI for managing [Deta Micros](/docs/micros/about).
 
-To install the CLI, check out [Installing the CLI](install).
+To install the CLI, check out [Installing the CLI](/docs/cli/install).
 
 
 #### Commands


### PR DESCRIPTION
Install URL broken when you visit the docs through Google. Doesn't replicate if you land here through other docs pages. Probably a bug in the frontend router though.

### Steps to replicate:

1. Google Search

![image](https://user-images.githubusercontent.com/36654812/186090400-ba575c97-8c50-4efb-9e56-d833eb1fff2a.png)

2. Land on CLI reference page

![Screenshot from 2022-08-23 12-18-44](https://user-images.githubusercontent.com/36654812/186090206-3895d217-b674-41dd-b2b5-d13cbd5d2d82.png)

3. Click on "Installing the CLI"

![Screenshot from 2022-08-23 12-20-00](https://user-images.githubusercontent.com/36654812/186090220-b177a374-3fbd-47c5-80c6-35c26931b0ea.png)
