### PR TITLE
Add info about empty keys in Base

### DIFF
--- a/docs/base/HTTP.md
+++ b/docs/base/HTTP.md
@@ -81,7 +81,6 @@ Stores multiple items in a single request. This request overwrites an item if th
         // rest of items
     ]
 }
-
 ```
 
 </TabItem>
@@ -124,6 +123,10 @@ Bad requests occur in the following cases:
 - if total request size exceeds 16 MB
 - if any individual item exceeds 400KB
 - if there are two items with identical keys
+
+:::info
+Empty keys in objects/dictionaries/structs, like `{"": "value"}` are invalid and will fail to be added during the backend processing stage.
+:::
 
 </TabItem>
 </Tabs>

--- a/docs/base/sdk.md
+++ b/docs/base/sdk.md
@@ -588,6 +588,9 @@ Returns the `key` of the item stored and an `error`. Possible error values:
 
 </Tabs>
 
+:::info
+Empty keys in objects/dictionaries/structs, like `{"": "value"}` are invalid and will fail to be added during the backend processing stage.
+:::
 
 ### Get
 


### PR DESCRIPTION
Added a note to the Base `PUT` docs mentioning that empty keys are invalid.
Currently the Python package does not handle this properly, but that is fixed in https://github.com/deta/deta-python/pull/76